### PR TITLE
ExposureCompensate: fix C4263

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
@@ -186,9 +186,8 @@ public:
     CV_WRAP int getNrGainsFilteringIterations() const { return nr_gain_filtering_iterations_; }
 
 protected:
-    template<class Compensator>
     void feed(const std::vector<Point> &corners, const std::vector<UMat> &images,
-              const std::vector<std::pair<UMat,uchar> > &masks);
+              const std::vector<std::pair<UMat,uchar> > &masks) CV_OVERRIDE;
 
 private:
     UMat getGainMap(const GainCompensator& compensator, int bl_idx, Size bl_per_img);

--- a/modules/stitching/src/exposure_compensate.cpp
+++ b/modules/stitching/src/exposure_compensate.cpp
@@ -459,7 +459,6 @@ void ChannelsCompensator::setMatGains(std::vector<Mat>& umv)
 }
 
 
-template<class Compensator>
 void BlocksCompensator::feed(const std::vector<Point> &corners, const std::vector<UMat> &images,
                              const std::vector<std::pair<UMat,uchar> > &masks)
 {


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
